### PR TITLE
Fix nullish optional chaining with loose equality

### DIFF
--- a/packages/unminify/src/transformations/__tests__/un-nullish-coalescing.spec.ts
+++ b/packages/unminify/src/transformations/__tests__/un-nullish-coalescing.spec.ts
@@ -178,6 +178,27 @@ function foo3(foo, bar = foo ?? "bar") {}
 `,
 )
 
+inlineTest('complex nested nullish and optional chaining',
+  `
+var a =
+      null !==
+        (t =
+          null == r ||
+          null === (n = r.app_info) ||
+          void 0 === n ||
+          null === (o = n.base_info) ||
+          void 0 === o
+            ? void 0
+            : o.app_name) && void 0 !== t
+        ? t
+        : "game";
+`,
+  `
+var a =
+      r?.app_info?.base_info?.app_name ?? "game";
+`,
+)
+
 inlineTest('TypeScript',
   `
 var _a, _b;

--- a/packages/unminify/src/utils/checker.ts
+++ b/packages/unminify/src/utils/checker.ts
@@ -46,19 +46,19 @@ export function isLogicalNot(j: JSCodeshift, node: ASTNode): node is UnaryExpres
 
 export function isNotNullBinary(j: JSCodeshift, node: ASTNode): node is BinaryExpression {
     return j.BinaryExpression.check(node)
-    && node.operator === '!=='
+    && (node.operator === '!==' || node.operator === '!=')
     && (isNull(j, node.left) || isNull(j, node.right))
 }
 
 export function isNullBinary(j: JSCodeshift, node: ASTNode): node is BinaryExpression {
     return j.BinaryExpression.check(node)
-    && node.operator === '==='
+    && (node.operator === '===' || node.operator === '==')
     && (isNull(j, node.left) || isNull(j, node.right))
 }
 
 export function isUndefinedBinary(j: JSCodeshift, node: ASTNode): node is BinaryExpression {
     return j.BinaryExpression.check(node)
-    && node.operator === '==='
+    && (node.operator === '===' || node.operator === '==')
     && (isUndefined(j, node.left) || isUndefined(j, node.right))
 }
 


### PR DESCRIPTION
- Fixes https://github.com/pionxzh/wakaru/issues/142
- Supercedes https://github.com/pionxzh/wakaru/pull/143

## Summary
- support `==`/`!=` patterns when detecting `null`/`undefined` comparisons
- add regression test for nested optional chain with nullish coalescing

## Testing
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-8.8.0.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_683fa84a6cc08328957488de43173afa

## See Also

- https://github.com/pionxzh/wakaru/issues/142
  - https://github.com/pionxzh/wakaru/pull/143