### PR TITLE
Handle loose null checks in optional chaining

### DIFF
--- a/packages/ast-utils/src/matchers/index.ts
+++ b/packages/ast-utils/src/matchers/index.ts
@@ -100,7 +100,7 @@ export function isLogicalNot(j: JSCodeshift, node: ASTNode): node is UnaryExpres
  */
 export function isNotNullBinary(j: JSCodeshift, node: ASTNode): node is BinaryExpression {
     return j.BinaryExpression.check(node)
-    && node.operator === '!=='
+    && (node.operator === '!==' || node.operator === '!=')
     && (isNull(j, node.left) || isNull(j, node.right))
 }
 
@@ -109,13 +109,13 @@ export function isNotNullBinary(j: JSCodeshift, node: ASTNode): node is BinaryEx
  */
 export function isNullBinary(j: JSCodeshift, node: ASTNode): node is BinaryExpression {
     return j.BinaryExpression.check(node)
-    && node.operator === '==='
+    && (node.operator === '===' || node.operator === '==')
     && (isNull(j, node.left) || isNull(j, node.right))
 }
 
 export function isUndefinedBinary(j: JSCodeshift, node: ASTNode): node is BinaryExpression {
     return j.BinaryExpression.check(node)
-    && node.operator === '==='
+    && (node.operator === '===' || node.operator === '==')
     && (isUndefined(j, node.left) || isUndefined(j, node.right))
 }
 

--- a/packages/unminify/src/transformations/__tests__/un-nullish-coalescing.spec.ts
+++ b/packages/unminify/src/transformations/__tests__/un-nullish-coalescing.spec.ts
@@ -296,3 +296,27 @@ null !== (o = null === (s = c.foo.bar) || void 0 === s ? void 0 : s.baz.z) && vo
 c.foo.bar?.baz.z ?? false;
 `,
 )
+
+defineInlineTest([unOptionalChaining, transform])('handles nested assignments with root checks',
+  `
+var t,
+    n,
+    o,
+    a =
+      null !==
+        (t =
+          null == r ||
+          null === (n = r.app_info) ||
+          void 0 === n ||
+          null === (o = n.base_info) ||
+          void 0 === o
+            ? void 0
+            : o.app_name) && void 0 !== t
+        ? t
+        : "game";
+  `,
+  `
+var a =
+  r?.app_info?.base_info?.app_name ?? "game";
+  `,
+)


### PR DESCRIPTION
- Fixes https://github.com/pionxzh/wakaru/issues/142
- Supercedes https://github.com/pionxzh/wakaru/pull/143
- Supercedes https://github.com/0xdevalias/wakaru/pull/1

## Summary

- support `==`/`!=` comparisons in matcher helpers
- handle loose equality when rebuilding optional chains
- add regression test for un-nullish-coalescing

## Testing

- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_683fdb13c63c8328857b97b06d08f73d